### PR TITLE
Reapply "Using correct ICC profile while exporting Webp Images (#410)…

### DIFF
--- a/vips/image.go
+++ b/vips/image.go
@@ -955,7 +955,9 @@ func (r *ImageRef) ExportWebp(params *WebpExportParams) ([]byte, *ImageMetadata,
 	}
 
 	paramsWithIccProfile := *params
-	paramsWithIccProfile.IccProfile = r.optimizedIccProfile
+	if r.optimizedIccProfile != "" && params.IccProfile == "" {
+		paramsWithIccProfile.IccProfile = r.optimizedIccProfile
+	}
 
 	buf, err := vipsSaveWebPToBuffer(r.image, paramsWithIccProfile)
 	if err != nil {

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -51,6 +51,29 @@ func TestImageRef_WebP__ReducedEffort(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestImageInbuildIcc_WebP(t *testing.T) {
+	Startup(nil)
+
+	srcBytes, err := os.ReadFile(resources + "jpg-24bit-icc-iec.jpg")
+	require.NoError(t, err)
+
+	img, err := NewImageFromBuffer(srcBytes)
+	require.NoError(t, err)
+	require.NotNil(t, img)
+
+	params := NewWebpExportParams()
+	exportedWebpBytes, _, err := img.ExportWebp(params)
+	assert.NoError(t, err)
+	assert.NotNil(t, exportedWebpBytes)
+
+	// Check if the exported webp has the same ICC profile as the original image
+	exportedImg, err := NewImageFromBuffer(exportedWebpBytes)
+	require.NoError(t, err)
+	require.NotNil(t, exportedImg)
+
+	assert.Equal(t, img.GetICCProfile(), exportedImg.GetICCProfile())
+}
+
 func TestImageRef_WebP__NearLossless(t *testing.T) {
 	Startup(nil)
 


### PR DESCRIPTION
…" (#412)

This reverts commit 48c38673aaf7242cd7397af5836102b41e128a99.